### PR TITLE
feat: Implement subscription cancellation and retrieval

### DIFF
--- a/src/modules/subscription/dto/cancel-subscription.dto.ts
+++ b/src/modules/subscription/dto/cancel-subscription.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsBoolean, IsString } from 'class-validator';
+
+export class CancelSubscriptionDto {
+  @ApiProperty({
+    description:
+      'Whether to cancel immediately or at the end of the current period',
+    default: false,
+    required: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  cancelImmediately?: boolean = false;
+
+  @ApiProperty({
+    description: 'Optional reason for cancellation (for internal tracking)',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  cancellationReason?: string;
+}

--- a/src/modules/subscription/dto/subscription-response.dto.ts
+++ b/src/modules/subscription/dto/subscription-response.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SubscriptionResponseDto {
+  @ApiProperty({ description: 'Stripe subscription ID' })
+  stripeSubscriptionId: string | null;
+
+  @ApiProperty({ description: 'Current subscription status' })
+  subscriptionStatus: string | null;
+
+  @ApiProperty({ description: 'Active Stripe price ID' })
+  activeStripePriceId: string | null;
+
+  @ApiProperty({ description: 'Current billing period end date' })
+  currentPeriodEnd: Date | null;
+
+  @ApiProperty({ description: 'Whether user has an active subscription' })
+  hasActiveSubscription: boolean;
+
+  @ApiProperty({ description: 'Current payment status' })
+  paymentStatus: string;
+
+  @ApiProperty({ description: 'Default payment method ID' })
+  defaultPaymentMethod: string | null;
+
+  @ApiProperty({ description: 'Last sync with Stripe' })
+  lastStripeSync: Date | null;
+}

--- a/src/modules/subscription/subscription.controller.ts
+++ b/src/modules/subscription/subscription.controller.ts
@@ -1,10 +1,13 @@
 import {
   Body,
   Controller,
+  Delete,
+  Get,
   HttpCode,
   HttpStatus,
   Post,
   Put,
+  Query,
   Req,
   UseGuards,
 } from '@nestjs/common';
@@ -14,6 +17,7 @@ import {
   ApiBody,
   ApiResponse,
   ApiOperation,
+  ApiQuery,
 } from '@nestjs/swagger';
 import { ApiResult } from '../../common/interfaces/response.interface';
 import { AuthGuard } from '../../common/guards/auth.guard';
@@ -22,6 +26,8 @@ import { CreateSubscriptionDto } from './dto/create-subscription.dto';
 import { SubscriptionService } from './subscription.service';
 import Stripe from 'stripe';
 import { ChangePlanDto } from './dto/change-subscription.dto';
+import { SubscriptionResponseDto } from './dto/subscription-response.dto';
+import { CancelSubscriptionDto } from './dto/cancel-subscription.dto';
 
 @ApiTags('stripe-subscriptions')
 @ApiBearerAuth()
@@ -87,18 +93,23 @@ export class SubscriptionController {
 
   @Put('change-plan')
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: 'Change (upgrade/downgrade) the authenticated user\'s active subscription plan' })
+  @ApiOperation({
+    summary:
+      "Change (upgrade/downgrade) the authenticated user's active subscription plan",
+  })
   @ApiBody({
     type: ChangePlanDto,
     description: 'Details of the new plan to switch to.',
   })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Subscription plan change initiated successfully. Check status for outcome.',
+    description:
+      'Subscription plan change initiated successfully. Check status for outcome.',
   })
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
-    description: 'Invalid input, no active subscription, or other update error.',
+    description:
+      'Invalid input, no active subscription, or other update error.',
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
@@ -111,22 +122,125 @@ export class SubscriptionController {
     const user = request['authenticatedData'];
     const userId = user._id.toString();
 
-    const updatedStripeSubscription = await this.subscriptionService.changeSubscriptionPlan(
-      userId,
-      changePlanDto,
-    );
-    
+    const updatedStripeSubscription =
+      await this.subscriptionService.changeSubscriptionPlan(
+        userId,
+        changePlanDto,
+      );
+
     let message = 'Subscription plan change initiated successfully.';
     if (updatedStripeSubscription.status === 'active') {
-        message = 'Subscription plan updated and active.';
+      message = 'Subscription plan updated and active.';
     } else if (updatedStripeSubscription.status === 'past_due') {
-        message = 'Subscription plan updated, but an immediate payment is past due.';
+      message =
+        'Subscription plan updated, but an immediate payment is past due.';
     }
 
     return {
       success: true,
       message: message,
-      data: updatedStripeSubscription
+      data: updatedStripeSubscription,
+    };
+  }
+
+  @Get('current')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: "Get the authenticated user's current subscription details",
+  })
+  @ApiQuery({
+    name: 'sync',
+    required: false,
+    type: Boolean,
+    description:
+      'Whether to sync with Stripe for the latest data (default: false)',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Subscription details retrieved successfully.',
+    type: SubscriptionResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'User not found.',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Error retrieving subscription details.',
+  })
+  async getCurrentSubscription(
+    @Req() request: ExtendedRequest,
+    @Query('sync') sync?: string,
+  ): Promise<ApiResult<SubscriptionResponseDto>> {
+    const user = request['authenticatedData'];
+    const userId = user._id.toString();
+    const shouldSync = sync === 'true' || sync === '1';
+
+    const subscriptionDetails =
+      await this.subscriptionService.getUserSubscription(userId, shouldSync);
+
+    let message = 'Subscription details retrieved successfully.';
+    if (shouldSync) {
+      message = 'Subscription details retrieved and synced with Stripe.';
+    }
+
+    return {
+      success: true,
+      message: message,
+      data: subscriptionDetails,
+    };
+  }
+
+  @Delete('cancel')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary:
+      "Cancel the authenticated user's active subscription (if any) immediately",
+  })
+  @ApiBody({
+    type: CancelSubscriptionDto,
+    description: 'Details of the cancellation request.',
+    required: false,
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description:
+      'Subscription cancellation initiated successfully. Check status for outcome.',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description:
+      'Invalid input, no active subscription, or other cancellation error.',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'User or active subscription not found.',
+  })
+  async cancelSubscription(
+    @Req() request: ExtendedRequest,
+    @Body() cancelSubscriptionDto: CancelSubscriptionDto = {},
+  ): Promise<ApiResult<Stripe.Subscription>> {
+    const user = request['authenticatedData'];
+    const userId = user._id.toString();
+
+    const cancelledSubscription =
+      await this.subscriptionService.cancelSubscription(
+        userId,
+        cancelSubscriptionDto,
+      );
+
+    let message = 'Subscription cancelled successfully.';
+    if (cancelSubscriptionDto.cancelImmediately) {
+      message = 'Subscription cancelled immediately.';
+    } else if (cancelledSubscription.cancel_at_period_end) {
+      message =
+        'Subscription will be cancelled at the end of the current billing period.';
+    }
+
+    return {
+      success: true,
+      message: message,
+      data: cancelledSubscription,
     };
   }
 }


### PR DESCRIPTION
- Added `CancelSubscriptionDto` for cancellation requests, including options for immediate cancellation and a cancellation reason.
- Implemented `DELETE /cancel` endpoint in `SubscriptionController` to allow users to cancel their active subscription.
- Implemented `cancelSubscription` method in `SubscriptionService` to handle the cancellation logic in Stripe, including immediate and end-of-period cancellations.
- Added `SubscriptionResponseDto` for returning subscription details.
- Implemented `GET /current` endpoint in `SubscriptionController` to retrieve the user's current subscription details, with an option to sync with Stripe.
- Implemented `getUserSubscription` method in `SubscriptionService` to retrieve and optionally sync subscription data with Stripe.
- Updated `handleCustomerSubscriptionUpdated` in `WebhookService` to handle subscription cancellation updates from Stripe.
- Added logic to update user subscription status and related fields in the database after cancellation.